### PR TITLE
Updating architectures in the executable.  

### DIFF
--- a/DeviceDNA.podspec
+++ b/DeviceDNA.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'DeviceDNA'
-  s.version               = '0.1.6'
+  s.version               = ‘0.1.8’
   s.summary               = 'Judopay Device DNA client for iOS'
   s.homepage              = 'http://judopay.com/'
   s.license               = 'MIT'


### PR DESCRIPTION
When creating the DeviceDNA executable I provided the parameters in the wrong order which meant the strip-frameworks stripped out the incorrect versions. 

Have updated release documentation.